### PR TITLE
Add Agent QA as a reference harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,6 @@ Read the source. This is the fastest way to learn the craft.
 - [Codex CLI](https://github.com/openai/codex) — OpenAI's, in Rust.
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) — Google's, Apache-2.0.
 - [Aider](https://github.com/Aider-AI/aider) — Mature, with unusually rigorous repo-map and edit-format engineering.
-- [Agent QA](https://github.com/vostride/agent-qa) — A TypeScript application-QA harness showing how persistent test memory, self-healing web/mobile flows, MCP tools, and evidence-backed failure triage fit into one runtime.
 - [OpenHands](https://github.com/All-Hands-AI/OpenHands) — Research-grade, fully open, strong sandboxing story.
 - [SWE-agent](https://github.com/SWE-agent/SWE-agent) — The ACI paper as running code.
 - [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent) — The same team's ~100-line counterpoint: bash as the only tool, no tool-calling API, yet >74% on SWE-bench Verified with a frontier model driving it. The sharpest datapoint in the minimalism debate.
@@ -290,6 +289,7 @@ Read the source. This is the fastest way to learn the craft.
 - [browser-use](https://github.com/browser-use/browser-use) — The dominant open browser harness: serialize the DOM into structured text with indexed interactive elements, so any LLM can act without vision.
 - [Stagehand](https://github.com/browserbase/stagehand) — Browserbase. Three primitives (act/observe/extract) over a Playwright-style API; choose per step between deterministic code and natural language, with caching and self-healing.
 - [Skyvern](https://github.com/Skyvern-AI/skyvern) — The vision-first counterpoint: vision LLMs plan over screenshots so automations survive site redesigns. AGPL-3.0 core with some capabilities held back for the proprietary cloud — a licensing pattern worth noticing.
+- [Agent QA](https://github.com/vostride/agent-qa) — A TypeScript application-QA harness showing how persistent test memory, self-healing web/mobile flows, MCP tools, and evidence-backed failure triage fit into one runtime. Note the FSL-1.1-ALv2 license — source-available, converts to Apache-2.0 after two years.
 
 ### Deep research
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Read the source. This is the fastest way to learn the craft.
 - [Pi](https://github.com/earendil-works/pi) — The minimalist counterpoint: a thin core of four tools (`read`, `write`, `edit`, `bash`) on the bet that frontier models already know what a coding agent is. Everything else lives in extensions you add deliberately.
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) — Google's, Apache-2.0.
 - [Aider](https://github.com/Aider-AI/aider) — Mature, with unusually rigorous repo-map and edit-format engineering.
+- [Agent QA](https://github.com/vostride/agent-qa) — A TypeScript application-QA harness showing how persistent test memory, self-healing web/mobile flows, MCP tools, and evidence-backed failure triage fit into one runtime.
 - [OpenHands](https://github.com/All-Hands-AI/OpenHands) — Research-grade, fully open, strong sandboxing story.
 - [SWE-agent](https://github.com/SWE-agent/SWE-agent) — The ACI paper as running code.
 - [Cline](https://github.com/cline/cline) — VS Code agent with an explicit plan/act split.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -265,7 +265,6 @@ Context window 就是 agent 的全部工作记忆，而且是一种稀缺的、�
 - [Codex CLI](https://github.com/openai/codex) —— OpenAI 的，Rust 写的。
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) —— Google 的，Apache-2.0。
 - [Aider](https://github.com/Aider-AI/aider) —— 成熟项目，repo-map 和 edit-format 的工程做得格外扎实。
-- [Agent QA](https://github.com/vostride/agent-qa) —— TypeScript 应用 QA harness，可从源码了解持久化测试记忆、Web/移动端自愈流程、MCP 工具和基于证据的失败分诊如何组合在同一运行时中。
 - [OpenHands](https://github.com/All-Hands-AI/OpenHands) —— 研究级、完全开源，沙箱方案很完整。
 - [SWE-agent](https://github.com/SWE-agent/SWE-agent) —— ACI 那篇论文的可运行版本。
 - [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent) —— 同一个团队约 100 行的对照组：唯一的工具是 bash，不用 tool-calling API，让前沿模型来开，照样在 SWE-bench Verified 上拿 >74%。极简主义之争里最锋利的一个数据点。
@@ -290,6 +289,7 @@ Context window 就是 agent 的全部工作记忆，而且是一种稀缺的、�
 - [browser-use](https://github.com/browser-use/browser-use) —— 占主导地位的开源 browser harness：把 DOM 序列化成带编号交互元素的结构化文本，任何 LLM 不靠视觉也能操作。
 - [Stagehand](https://github.com/browserbase/stagehand) —— Browserbase。在 Playwright 风格的 API 上架三个原语（act/observe/extract）；每一步都可以在确定性代码和自然语言之间选，带缓存和 self-healing。
 - [Skyvern](https://github.com/Skyvern-AI/skyvern) —— 视觉优先的对照组：vision LLM 对着截图做规划，网站改版了自动化也不死。AGPL-3.0 内核，部分能力留给闭源云 —— 这种许可模式值得留意。
+- [Agent QA](https://github.com/vostride/agent-qa) —— TypeScript 应用 QA harness，可从源码了解持久化测试记忆、Web/移动端自愈流程、MCP 工具和基于证据的失败分诊如何组合在同一运行时中。注意 FSL-1.1-ALv2 许可 —— source-available，两年后转 Apache-2.0。
 
 ### Deep Research
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,6 +159,7 @@ Context window 就是 agent 的全部工作记忆，而且是一种稀缺的、�
 - [Pi](https://github.com/earendil-works/pi) —— 极简主义的对照组：只有 `read`、`write`、`edit`、`bash` 四个工具的薄内核，赌的是前沿模型本来就知道 coding agent 是怎么回事。其余一切都放进你主动加回来的 extension 里。
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) —— Google 的，Apache-2.0。
 - [Aider](https://github.com/Aider-AI/aider) —— 成熟项目，repo-map 和 edit-format 的工程做得格外扎实。
+- [Agent QA](https://github.com/vostride/agent-qa) —— TypeScript 应用 QA harness，可从源码了解持久化测试记忆、Web/移动端自愈流程、MCP 工具和基于证据的失败分诊如何组合在同一运行时中。
 - [OpenHands](https://github.com/All-Hands-AI/OpenHands) —— 研究级、完全开源，沙箱方案很完整。
 - [SWE-agent](https://github.com/SWE-agent/SWE-agent) —— ACI 那篇论文的可运行版本。
 - [Cline](https://github.com/cline/cline) —— VS Code agent，plan/act 分离做得很显式。


### PR DESCRIPTION
## Summary

Add [Agent QA](https://github.com/vostride/agent-qa) to the English and Chinese Reference Harnesses sections.

This is framed as a source-reading reference rather than a product announcement: the entry calls out the concrete harness design visible in the TypeScript repository—persistent test memory, self-healing web/mobile flows, MCP tools, structured evidence, and failure triage in one application-QA runtime.

## Verification

I independently installed the published package in a fresh Node.js 24 project, loaded its CLI, initialized a web workspace, and validated both generated example test definitions. I did not configure a model provider or run a complete browser flow, so this PR makes no claim beyond that checked boundary.

- `git diff --check`
- English and Chinese entries are synchronized
- direct canonical repository link

The current release is source-available under FSL-1.1-ALv2 rather than OSI open source.

Disclosure: I am affiliated with Agent QA.
